### PR TITLE
[#3] 레슨 결과 화면 개선 (완료/오답 재도전 요약)

### DIFF
--- a/src/app/play/play.module.scss
+++ b/src/app/play/play.module.scss
@@ -1,1 +1,33 @@
 @import '../page.module.scss';
+
+.summaryGrid {
+  margin-top: 12px;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px;
+}
+
+.summaryItem {
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+  padding: 8px 10px;
+}
+
+.summaryLabel {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.7);
+  font-weight: 700;
+}
+
+.summaryValue {
+  margin-top: 4px;
+  font-size: 16px;
+  font-weight: 900;
+}
+
+@media (max-width: 520px) {
+  .summaryGrid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## What\n- 레슨 완료 오버레이에 결과 요약 카드 추가\n  - 총 문제 수\n  - 1차 정답(개수/비율)\n  - 오답 재도전 수\n  - 재도전 해결 수\n  - 남은 약점(2회 실패 스킵)\n- 완료 화면에 추천 다음 모드 버튼 추가\n\n## Why\n- 레슨 종료 시 학습 성과를 명확히 보여줘야 다음 행동(재도전/다음 모드)으로 자연스럽게 연결됨\n\n## Test\n- [x] npm run build\n- [x] npm test\n- [x] 완료 오버레이에서 요약 수치/버튼 동작 수동 확인\n\nCloses #3