### PR TITLE
[#4] 힌트 애니메이션 1차 (덧셈 블록 증가 시각화)

### DIFF
--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -17,6 +17,33 @@ import styles from './play.module.scss';
 
 type Feedback = { kind: 'none' | 'correct' | 'wrong' };
 
+function HintVisual({ problem }: { problem: AddProblem }) {
+  if (problem.kind === 'ARITH_CHOICE') {
+    const a = problem.a;
+    const b = problem.b;
+    return (
+      <div className={styles.arithHint}>
+        <div className={styles.hintRow}>
+          {Array.from({ length: a }).map((_, i) => (
+            <div key={`a-${i}`} className={styles.hintCellA} />
+          ))}
+        </div>
+        <div className={styles.hintRow}>
+          {Array.from({ length: b }).map((_, i) => (
+            <div key={`b-${i}`} className={styles.hintCellB} style={{ animationDelay: `${i * 60}ms` }} />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.renderHintWrap}>
+      <RenderView spec={problem.renderSpec} />
+    </div>
+  );
+}
+
 type PersistedPlaySession = {
   v: 1;
   modeId: string;
@@ -384,10 +411,10 @@ export default function PlayPage() {
                     </div>
                   )}
 
-                  {hintOpen && (
+                  {hintOpen && current && (
                     <div className={styles.hint}>
                       <div className={styles.hintCard}>
-                        <div className={styles.hintCanvas} aria-hidden />
+                        <HintVisual problem={current} />
                       </div>
                     </div>
                   )}

--- a/src/app/play/play.module.scss
+++ b/src/app/play/play.module.scss
@@ -1,5 +1,63 @@
 @import '../page.module.scss';
 
+.arithHint {
+  min-height: 170px;
+  border-radius: 14px;
+  border: 1px dashed rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.03);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 10px;
+  padding: 16px;
+}
+
+.hintRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+}
+
+.hintCellA,
+.hintCellB {
+  width: 22px;
+  height: 22px;
+  border-radius: 7px;
+}
+
+.hintCellA {
+  background: rgba(124, 92, 255, 0.88);
+}
+
+.hintCellB {
+  background: rgba(46, 196, 182, 0.9);
+  opacity: 0;
+  animation: popIn 420ms ease forwards;
+}
+
+.renderHintWrap {
+  min-height: 170px;
+  border-radius: 14px;
+  border: 1px dashed rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.03);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+}
+
+@keyframes popIn {
+  from {
+    opacity: 0;
+    transform: scale(0.6);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
 .summaryGrid {
   margin-top: 12px;
   display: grid;


### PR DESCRIPTION
## What\n- 힌트 표시를 빈 캔버스에서 실제 시각 힌트로 변경\n- 산술 문제(ARITH_CHOICE): a 블록 + b 블록이 순차적으로 나타나는 애니메이션\n- 도형 개수세기(RENDER_CHOICE_COUNT): 기존 RenderView를 힌트 배경에서 재사용\n- 힌트는 스테이지 배경 레이어에서 자동 닫힘 흐름 유지\n\n## Why\n- 텍스트 힌트보다 직관적이고, 저학년 사용자에게 이해가 쉬움\n\n## Test\n- [x] npm run build\n- [x] npm test\n- [x] 힌트 버튼 → 배경 힌트 애니메이션 노출/자동닫힘 수동 확인\n\nCloses #4